### PR TITLE
fix (attempt 2): Attempt to clean up state more thoroughly when grab fails 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.js]
+indent_style = space
+indent_size = 4

--- a/navigator.js
+++ b/navigator.js
@@ -79,7 +79,7 @@ class ActionDispatcher {
         this.actor = Tiling.spaces.spaceContainer;
         this.actor.set_flags(Clutter.ActorFlags.REACTIVE);
         this.navigator = getNavigator();
-		this.success = true;
+        this.success = true;
 
         if (grab) {
             Utils.debug("#dispatch", "already in grab");
@@ -92,19 +92,19 @@ class ActionDispatcher {
         if ((grab.get_seat_state() & Clutter.GrabState.KEYBOARD) === 0) {
             console.error("[Fix-Attempt-2] Failed to grab modal - failing gracefully");
 
-			// Release the current grab which does not match what we want.
-			// Set `grab` to `null`. So, we will attempt to grab the keyboard again next time.
-			this.success = false;
-			try {
-				if (grab) {
-					Main.popModal(grab);
-					grab = null;
-				}
-			} catch (e) {
-				Utils.debug("[Fix-Attempt-2] Failed to release grab: ", e);
-			}
+            // Release the current grab which does not match what we want.
+            // Set `grab` to `null`. So, we will attempt to grab the keyboard again next time.
+            this.success = false;
+            try {
+                if (grab) {
+                    Main.popModal(grab);
+                    grab = null;
+                }
+            } catch (e) {
+                Utils.debug("[Fix-Attempt-2] Failed to release grab: ", e);
+            }
 
-			return;
+            return;
         }
 
         this.signals.connect(this.actor, 'key-press-event', this._keyPressEvent.bind(this));
@@ -115,8 +115,8 @@ class ActionDispatcher {
     }
 
     show(backward, binding, mask) {
-		// If grab was not successful, don't try to do this.
-		if (!this.success) return;
+        // If grab was not successful, don't try to do this.
+        if (!this.success) return;
 
         this._modifierMask = getModLock(mask);
         this.navigator = getNavigator();
@@ -459,16 +459,16 @@ function finishNavigation(force = false) {
  */
 function getActionDispatcher(mode) {
     if (dispatcher === null) {
-		dispatcher = new ActionDispatcher();
+        dispatcher = new ActionDispatcher();
 
-		if (!dispatcher.success) {
+        if (!dispatcher.success) {
             console.error("[Fix-Attempt-2] Action dispatcher creation was not successful");
-			return dispatcher;
-		}
+            return dispatcher;
+        }
     }
 
-	dispatcher.mode |= mode;
-	return dispatcher;
+    dispatcher.mode |= mode;
+    return dispatcher;
 }
 
 /**
@@ -495,11 +495,11 @@ function dismissDispatcher(mode) {
 
 function preview_navigate(meta_window, space, { display, screen, binding }) {
     let tabPopup = getActionDispatcher(Clutter.GrabState.KEYBOARD);
-	// Getting the action dispatcher does not always succeed. In the cases where it does not
-	// succeed, attempt to fail gracefully by destroying what we created and returning silently.
-	if (!tabPopup.success) {
-		tabPopup.destroy();
-	} else {
-		tabPopup.show(binding.is_reversed(), binding.get_name(), binding.get_mask());
-	}
+    // Getting the action dispatcher does not always succeed. In the cases where it does not
+    // succeed, attempt to fail gracefully by destroying what we created and returning silently.
+    if (!tabPopup.success) {
+        tabPopup.destroy();
+    } else {
+        tabPopup.show(binding.is_reversed(), binding.get_name(), binding.get_mask());
+    }
 }

--- a/navigator.js
+++ b/navigator.js
@@ -90,7 +90,7 @@ class ActionDispatcher {
         grab = Main.pushModal(this.actor);
         // We expect at least a keyboard grab here
         if ((grab.get_seat_state() & Clutter.GrabState.KEYBOARD) === 0) {
-            console.error("[Fix-Attempt-2] Failed to grab modal - failing gracefully");
+            console.error("[Fix-Attempt-2: grab modal] Failed to grab modal - failing gracefully");
 
             // Release the current grab which does not match what we want.
             // Set `grab` to `null`. So, we will attempt to grab the keyboard again next time.
@@ -101,7 +101,7 @@ class ActionDispatcher {
                     grab = null;
                 }
             } catch (e) {
-                Utils.debug("[Fix-Attempt-2] Failed to release grab: ", e);
+                Utils.debug("[Fix-Attempt-2: grab modal] Failed to release grab: ", e);
             }
 
             return;
@@ -458,16 +458,19 @@ function finishNavigation(force = false) {
  * @returns {ActionDispatcher}
  */
 function getActionDispatcher(mode) {
-    if (dispatcher === null) {
-        dispatcher = new ActionDispatcher();
-
-        if (!dispatcher.success) {
-            console.error("[Fix-Attempt-2] Action dispatcher creation was not successful");
-            return dispatcher;
-        }
+    // Falsy values include null, undefined, and a few other values. Everything else in Javascript
+    // is truthy.
+    // https://developer.mozilla.org/en-US/docs/Glossary/Falsy
+    if (dispatcher) {
+        dispatcher.mode |= mode;
+        return dispatcher;
     }
 
-    dispatcher.mode |= mode;
+    dispatcher = new ActionDispatcher();
+    if (!dispatcher.success) {
+        console.error("[Fix-Attempt-2: grab modal] Action dispatcher creation was not successful");
+    }
+
     return dispatcher;
 }
 

--- a/navigator.js
+++ b/navigator.js
@@ -79,6 +79,7 @@ class ActionDispatcher {
         this.actor = Tiling.spaces.spaceContainer;
         this.actor.set_flags(Clutter.ActorFlags.REACTIVE);
         this.navigator = getNavigator();
+		this.success = true;
 
         if (grab) {
             Utils.debug("#dispatch", "already in grab");
@@ -89,8 +90,21 @@ class ActionDispatcher {
         grab = Main.pushModal(this.actor);
         // We expect at least a keyboard grab here
         if ((grab.get_seat_state() & Clutter.GrabState.KEYBOARD) === 0) {
-            console.error("Failed to grab modal");
-            throw new Error('Could not grab modal');
+            console.error("[Fix-Attempt-2] Failed to grab modal - failing gracefully");
+
+			// Release the current grab which does not match what we want.
+			// Set `grab` to `null`. So, we will attempt to grab the keyboard again next time.
+			this.success = false;
+			try {
+				if (grab) {
+					Main.popModal(grab);
+					grab = null;
+				}
+			} catch (e) {
+				Utils.debug("[Fix-Attempt-2] Failed to release grab: ", e);
+			}
+
+			return;
         }
 
         this.signals.connect(this.actor, 'key-press-event', this._keyPressEvent.bind(this));
@@ -101,6 +115,9 @@ class ActionDispatcher {
     }
 
     show(backward, binding, mask) {
+		// If grab was not successful, don't try to do this.
+		if (!this.success) return;
+
         this._modifierMask = getModLock(mask);
         this.navigator = getNavigator();
         TopBar.fixTopBar();
@@ -441,16 +458,21 @@ function finishNavigation(force = false) {
  * @returns {ActionDispatcher}
  */
 function getActionDispatcher(mode) {
-    if (dispatcher) {
-        dispatcher.mode |= mode;
-        return dispatcher;
+    if (dispatcher === null) {
+		dispatcher = new ActionDispatcher();
+
+		if (!dispatcher.success) {
+            console.error("[Fix-Attempt-2] Action dispatcher creation was not successful");
+			return dispatcher;
+		}
     }
-    dispatcher = new ActionDispatcher();
-    return getActionDispatcher(mode);
+
+	dispatcher.mode |= mode;
+	return dispatcher;
 }
 
 /**
- * Fishes current dispatcher (if any).
+ * Finishes current dispatcher (if any).
  */
 function finishDispatching() {
     dispatcher?._finish(global.get_current_time());
@@ -473,5 +495,11 @@ function dismissDispatcher(mode) {
 
 function preview_navigate(meta_window, space, { display, screen, binding }) {
     let tabPopup = getActionDispatcher(Clutter.GrabState.KEYBOARD);
-    tabPopup.show(binding.is_reversed(), binding.get_name(), binding.get_mask());
+	// Getting the action dispatcher does not always succeed. In the cases where it does not
+	// succeed, attempt to fail gracefully by destroying what we created and returning silently.
+	if (!tabPopup.success) {
+		tabPopup.destroy();
+	} else {
+		tabPopup.show(binding.is_reversed(), binding.get_name(), binding.get_mask());
+	}
 }

--- a/navigator.js
+++ b/navigator.js
@@ -471,6 +471,7 @@ function getActionDispatcher(mode) {
         console.error("[Fix-Attempt-2: grab modal] Action dispatcher creation was not successful");
     }
 
+    dispatcher.mode |= mode;
     return dispatcher;
 }
 


### PR DESCRIPTION
An improvement to the first attempt at this fix here: #1 

With this change, I am attempting to clean up the state right up until the caller of the preview_navigate function.

If this does not work, then disabling the minimap would be the only option. The minimap is probably the reason that preview_navigate is called as the key handler.

When the minimap is open, both the keyboard and mouse are taken by the minimap. The minimap does not respond to mouse click events, however, it responds to scroll and keypress down events as long as the modifier key is pressed.

There might be some way to make the minimap not even require a grab in the first place. (Scrolling through the windows in the minimap does not seem like a very useful feature anyway.) This could be a potential avenue to go down if this attempt does not work.